### PR TITLE
Blocks delete bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * fix a few still-broken React Selects.
 * remove deprecated sponsor-picker-field
 * implement pre-push git hooks
+* fixed sweetalert call to solve issue deleting blocks
 
 
 ## v0.1.0

--- a/src/plugins/blocksmith/components/blocksmith/index.jsx
+++ b/src/plugins/blocksmith/components/blocksmith/index.jsx
@@ -91,7 +91,7 @@ import './styles.scss';
 
 class Blocksmith extends React.Component {
   static async confirmDelete() {
-    return swal({
+    return swal.fire({
       title: 'Are you sure?',
       text: 'This block will be deleted',
       type: 'warning',
@@ -673,7 +673,7 @@ class Blocksmith extends React.Component {
   handleDelete() {
     const { activeBlockKey, editorState, isDirty } = this.state;
     const { delegate, formName } = this.props;
-
+    
     this.setState({ readOnly: true }, () => {
       Blocksmith.confirmDelete().then((result) => {
         this.setState({ readOnly: false }, () => {


### PR DESCRIPTION
The bug was associated to sweet alerts.  The API has been updated. "swal" is now an object which has a method "fire".