### PR TITLE
fix for node picker crashing when node is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # CHANGELOG
 
-## vN.N.N
-* issue #51: Update regex instagram block modal.
-
 
 ## patch
 * Add Label for to `GalleryFields` for related galleries title
@@ -22,6 +19,8 @@
 * increase width of value field in key-values-field
 * fix asset variant dropzone spinner
 * pre-fill notification modal when opened from article screen
+* issue #51: Update regex instagram block modal.
+* fix for node picker crashing when node is not found
 
 
 ## v0.1.1

--- a/src/plugins/ncr/components/node-picker-field/selector.js
+++ b/src/plugins/ncr/components/node-picker-field/selector.js
@@ -30,11 +30,14 @@ export default (state, { constants, fields, schemas, isGetAll, optionsMapper = n
   const value = getMemoizedValues(
     cacheKey,
     allFields,
-    optionsMapper || ((nodeRef) => ({
-      label: getNode(state, nodeRef).get('title'),
-      value: nodeRef,
-      node: getNode(state, nodeRef),
-    })),
+    optionsMapper || ((nodeRef) => {
+      const node = getNode(state, nodeRef);
+      return {
+        label: node ? node.get('title') : '',
+        value: nodeRef,
+        node,
+      };
+    }),
   );
 
   return {


### PR DESCRIPTION
page will crash if a selected node is not found (deleted etc). this fixes that