### PR TITLE
fix blocksmith inline toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Bug: Unable to paste into slug field(URL) and keep formatting.
 * Fix picker not scrolling which was actually options being filtered.
 * Bug: block modal search bar non functional
+* fix blocksmith inline toolbar
 
 
 ## v0.2.1

--- a/src/plugins/blocksmith/components/blocksmith/index.jsx
+++ b/src/plugins/blocksmith/components/blocksmith/index.jsx
@@ -177,22 +177,6 @@ class Blocksmith extends React.Component {
     delegate.handleStoreEditor(formName, editorState);
 
     this.inlineToolbarPlugin = createInlineToolbarPlugin({
-      structure: [
-        BoldButton,
-        ItalicButton,
-        UnderlineButton,
-        decorateComponentWithProps(
-          LinkButton,
-          {
-            onToggleLinkModal: this.handleToggleLinkModal.bind(this),
-            getEditorState: this.getEditorState.bind(this),
-          },
-        ),
-        OrderedListButton,
-        UnorderedListButton,
-        StrikethroughButton,
-        HighlightButton,
-      ],
       theme: {
         toolbarStyles: {
           toolbar: 'inline-toolbar',
@@ -1683,6 +1667,7 @@ class Blocksmith extends React.Component {
     } = this.state;
     let className = readOnly ? 'view-mode' : 'edit-mode';
     className = `${className}${!editorState.getCurrentContent().hasText() ? ' empty' : ''}`;
+    const InlineToolbar = this.inlineToolbarPlugin.InlineToolbar;
 
     return (
       <Card>
@@ -1751,7 +1736,24 @@ class Blocksmith extends React.Component {
                 popoverRef={this.popoverRef}
               />
             </div>
-            {this.pluginComponents.map(({ key, PluginComponent }) => <PluginComponent key={key} />)}
+            <InlineToolbar>
+              {(props) => (
+                <>
+                  <BoldButton {...props} />
+                  <ItalicButton {...props} />
+                  <UnderlineButton {...props} />
+                  <LinkButton
+                    {...props}
+                    onToggleLinkModal={this.handleToggleLinkModal}
+                    getEditorState={this.getEditorState}
+                  />
+                  <OrderedListButton {...props} />
+                  <UnorderedListButton {...props} />
+                  <StrikethroughButton {...props} />
+                  <HighlightButton {...props} />
+                </>
+              )}
+            </InlineToolbar>
             {Modal && <Modal />}
           </div>
           {!readOnly && (


### PR DESCRIPTION
they updated to use render props instead of the structure prop array