### PR TITLE
reduce delays in linkAssetsFlow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## vN.N.N
+* decrease race timeout to 1 second in `linkAssetsFlow` and remove delay on `successFlow` in `linkAssetsFlow`.
+
+
 ## v0.2.4
 * update all node pickers to request 25 per page
 * fix `nodePickerField` double scrollbar and overflow issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## vN.N.N
-* decrease race timeout to 1 second in `linkAssetsFlow` and remove delay on `successFlow` in `linkAssetsFlow`.
+* remove delay on `successFlow` and move up toast fork in `linkAssetsFlow`.
 
 
 ## v0.2.4

--- a/src/plugins/dam/sagas/linkAssetsFlow.js
+++ b/src/plugins/dam/sagas/linkAssetsFlow.js
@@ -88,7 +88,7 @@ export default function* linkAssetsFlow({ pbj, resolve, reject, config }) {
   const eventChannel = yield actionChannel(expectedEvent);
   const result = yield race({
     event: call(waitForMyEvent, eventChannel),
-    timeout: delay(1000),
+    timeout: delay(5000),
   });
 
   if (result.timeout) {

--- a/src/plugins/dam/sagas/linkAssetsFlow.js
+++ b/src/plugins/dam/sagas/linkAssetsFlow.js
@@ -82,10 +82,10 @@ export function* failureFlow(reject, error = null, failedCount, expectedCount) {
  * @param config
  */
 export default function* linkAssetsFlow({ pbj, resolve, reject, config }) {
+  yield fork([toast, 'show']);
   yield putResolve(pbj);
   const expectedEvent = config.schemas.assetLinked.getCurie().toString();
   const eventChannel = yield actionChannel(expectedEvent);
-  yield fork([toast, 'show']);
   const result = yield race({
     event: call(waitForMyEvent, eventChannel),
     timeout: delay(1000),

--- a/src/plugins/dam/sagas/linkAssetsFlow.js
+++ b/src/plugins/dam/sagas/linkAssetsFlow.js
@@ -33,7 +33,6 @@ export function* successFlow(resolve, { schemas, numAssets }) {
     pbjxChannelNamesImage.MEDIA_SEARCH,
   ));
 
-  yield delay(500);
   yield call(resolve);
   yield call([toast, 'close']);
   yield swal.fire({
@@ -89,7 +88,7 @@ export default function* linkAssetsFlow({ pbj, resolve, reject, config }) {
   yield fork([toast, 'show']);
   const result = yield race({
     event: call(waitForMyEvent, eventChannel),
-    timeout: delay(5000),
+    timeout: delay(1000),
   });
 
   if (result.timeout) {


### PR DESCRIPTION
* decrease race timeout to 1 second in `linkAssetsFlow` and remove delay on `successFlow` in `linkAssetsFlow`.