### PR TITLE
re-enable collaboration reducer on MESSAGE_RECEIVED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## vX.X.X
 * Can edit ad-widget size while in view mode
 * Remove error message when editing/creating slugs
+* Re-enable collaboration reducer on `MESSAGE_RECEIVED`.
 
 
 ## v0.2.10

--- a/src/plugins/raven/reducers/collaboration.js
+++ b/src/plugins/raven/reducers/collaboration.js
@@ -53,5 +53,5 @@ export default createReducer(initialState, {
   [actionTypes.HEARTBEAT]: onCollaboratorJoinedOrHeartbeat,
   [actionTypes.COLLABORATOR_JOINED]: onCollaboratorJoinedOrHeartbeat,
   [actionTypes.COLLABORATOR_LEFT]: onCollaboratorLeft,
-  // [actionTypes.MESSAGE_RECEIVED]: onMessageReceived,
+  [actionTypes.MESSAGE_RECEIVED]: onMessageReceived,
 });


### PR DESCRIPTION
when the files were copied over from the scottish repo, this line was commented out for some reason: https://github.com/triniti/cms-js/pull/1/commits/32859f5c95773eb296e8f52759236e6120104c83#diff-dc8a7b89911858b145a42c518c22dc39R56