### PR TITLE
MediaLive tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## vN.N.N
 * issue #1035: Add Spotify Embed Block
 * include status in `MediaLiveChannelCards` Card headers.
+* MediaLive tweaks: increase delay waiting for event, add toast message, and add "no videos found" message
 
 
 ## v0.2.16

--- a/src/plugins/ovp/sagas/startMediaLiveChannelFlow.js
+++ b/src/plugins/ovp/sagas/startMediaLiveChannelFlow.js
@@ -21,13 +21,13 @@ function* failureFlow(error) {
 
 export default function* startMediaLiveChannelFlow({ pbj }) {
   try {
-    yield fork([toast, 'show']);
+    yield fork([toast, 'show'], 'starting channel');
     const eventChannel = yield actionChannel(ChannelStarted.schema().getCurie().toString());
     yield putResolve(pbj);
 
     const result = yield race({
       event: call(waitForMyEvent, eventChannel),
-      timeout: delay(240000),
+      timeout: delay(480 * 1000),
     });
 
     if (result.timeout) {

--- a/src/plugins/ovp/sagas/stopMediaLiveChannelFlow.js
+++ b/src/plugins/ovp/sagas/stopMediaLiveChannelFlow.js
@@ -21,13 +21,13 @@ function* failureFlow(error) {
 
 export default function* stopMediaLiveChannelFlow({ pbj }) {
   try {
-    yield fork([toast, 'show']);
+    yield fork([toast, 'show'], 'stopping channel');
     const eventChannel = yield actionChannel(ChannelStopped.schema().getCurie().toString());
     yield putResolve(pbj);
 
     const result = yield race({
       event: call(waitForMyEvent, eventChannel),
-      timeout: delay(240000),
+      timeout: delay(480 * 1000),
     });
 
     if (result.timeout) {

--- a/src/plugins/ovp/screens/medialive/index.jsx
+++ b/src/plugins/ovp/screens/medialive/index.jsx
@@ -47,7 +47,12 @@ class MediaLiveScreen extends React.Component {
           if (exception) {
             return <StatusMessage status={status} exception={exception} />;
           }
-          return isFulfilled ? <MediaLiveChannelCards nodes={nodes} /> : <Spinner />;
+          if (!isFulfilled) {
+            return <Spinner />;
+          }
+          return nodes.length === 0
+            ? <p>No videos with MediaLive Channels found.</p>
+            : <MediaLiveChannelCards nodes={nodes} />;
         })()}
         title="Livestreams"
       />


### PR DESCRIPTION
increase delay waiting for event, add toast message, and add 'no videos found' message.

stopping the channel was "timing out" on client because the server was taking too long. the new delay is the max the server will keep trying for plus 30 seconds