### PR TITLE
Uncheck Selected Images After Successful Batch Edit Submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## vN.N.N
 * Editing a slug during creation modal will result in a blank slug when hitting ENTER
 * Add More Fields On Designated Screens (display_title, credit_url, cta_text, cta_url, etc.)
+* Unselected images from Batch Edit once User clicks update.
 
 
 ## v0.3.3
@@ -11,7 +12,7 @@
 
 
 ## v0.3.2
-* Add Spotify URI to text area of spotify embed block to make it more clear which content type is being used. 
+* Add Spotify URI to text area of spotify embed block to make it more clear which content type is being used.
 * Spotify Embed Block requires pasting of embeds twice.
 * YouTube Playlist block: If user manually types anything into input field for EMBED CODE, URL, OR ID the CMS will crash
 * Text Editor toolbar does not appear after selecting option, leaving tab, and returning

--- a/src/plugins/curator/components/gallery-media/selector.js
+++ b/src/plugins/curator/components/gallery-media/selector.js
@@ -1,5 +1,7 @@
+import getCommand from '@triniti/cms/plugins/pbjx/selectors/getCommand';
 import getRequest from '@triniti/cms/plugins/pbjx/selectors/getRequest';
 import isGranted from '@triniti/cms/plugins/iam/selectors/isGranted';
+import PatchAssetsV1Mixin from '@triniti/schemas/triniti/dam/mixin/patch-assets/PatchAssetsV1Mixin';
 import schemas from './schemas';
 import { pbjxChannelNames } from '../../constants';
 
@@ -16,12 +18,14 @@ export default (state) => {
     pbjxChannelNames.GALLERY_MEDIA_SEARCH,
   );
 
+  const patchAssetsCommandState = getCommand(state, PatchAssetsV1Mixin.findOne().getCurie());
   const { response } = searchNodesRequestState;
   const isReorderGranted = isGranted(state, `${schemas.reorderGalleryAssets.getCurie()}`);
 
   return {
     nodes: response ? response.get('nodes', []) : [],
     isReorderGranted,
+    patchAssetsCommandState,
     searchNodesRequestState,
   };
 };

--- a/src/plugins/dam/sagas/patchAssetsFlow.js
+++ b/src/plugins/dam/sagas/patchAssetsFlow.js
@@ -6,11 +6,9 @@ import waitForMyEvent from '@triniti/cms/plugins/ncr/sagas/waitForMyEvent';
 import OperationTimedOut from '@triniti/cms/plugins/pbjx/exceptions/OperationTimedOut';
 
 /**
- * @param {Function} resolve
- * @param {Object} history
  * @param {Object} config
  */
-export function* successFlow(id, config) {
+export function* successFlow(config) {
   yield call([toast, 'close']);
   const message = get(config, 'action.successMsg', 'Success! File have been updated.');
   yield put(sendAlert({
@@ -23,7 +21,6 @@ export function* successFlow(id, config) {
 
 /**
  * command failure handler
- * @param {Function} reject
  * @param {Object} error
  */
 export function* failureFlow(error) {


### PR DESCRIPTION
This update will uncheck all selected checkboxes inside the gallery media component once user successfully submitted the batch edit operation. Accomplished by watching the `patch-asset` command if it's status is in `STATUS_FULFILLED`.