### PR TITLE
remove send now option from disable_send_now options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add More Fields On Designated Screens (display_title, credit_url, cta_text, cta_url, etc.)
 * Uploading a new pdf to a content block does not auto select or show up
 * Unselected images from Batch Edit once User clicks update.
+* issue #1085: Adjust Notification Send Options To Exclude 'Send Now' On Unpublished Content
 
 
 ## v0.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add More Fields On Designated Screens (display_title, credit_url, cta_text, cta_url, etc.)
 * Uploading a new pdf to a content block does not auto select or show up
 * Unselected images from Batch Edit once User clicks update.
-* issue #1085: Adjust Notification Send Options To Exclude 'Send Now' On Unpublished Content
+* Adjust Notification Send Options To Exclude 'Send Now' On Unpublished Content
 
 
 ## v0.3.4

--- a/src/plugins/notify/components/notification-fields/index.jsx
+++ b/src/plugins/notify/components/notification-fields/index.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import startCase from 'lodash/startCase';
 import { Field } from 'redux-form';
 
 import DatePickerField from '@triniti/cms/components/date-picker-field';
@@ -25,12 +26,18 @@ import {
 import { formConfigs } from '../../constants';
 
 const NotificationFields = ({ app, content, isEditMode, node, showDatePicker }) => {
-  const { DISABLE_SEND_NOW, DISABLE_SEND_ON_PUBLISH } = formConfigs.SEND_OPTIONS;
   const sendStatus = node.get('send_status');
-  let sendOptions = DISABLE_SEND_NOW;
+  const { SEND_NOW, SCHEDULE_SEND, SEND_ON_PUBLISH } = formConfigs.SEND_OPTIONS;
+  const sendOptions = [
+    { label: startCase(SEND_NOW.replace('-', ' ')), value: SEND_NOW },
+    { label: startCase(SCHEDULE_SEND.replace('-', ' ')), value: SCHEDULE_SEND },
+    { label: startCase(SEND_ON_PUBLISH.replace('-', ' ')), value: SEND_ON_PUBLISH },
+  ];
 
   if (!node.has('content_ref') || content.get('status') === NodeStatus.PUBLISHED) {
-    sendOptions = DISABLE_SEND_ON_PUBLISH;
+    sendOptions[2].isDisabled = true;
+  } else {
+    sendOptions[0].isDisabled = true;
   }
 
   return (

--- a/src/plugins/notify/constants.js
+++ b/src/plugins/notify/constants.js
@@ -40,19 +40,6 @@ export const formConfigs = {
     SEND_NOW: 'send-now',
     SCHEDULE_SEND: 'schedule-send',
     SEND_ON_PUBLISH: 'send-on-publish',
-    DISABLE_SEND_NOW: [
-      { label: 'Schedule Send', value: 'schedule-send' },
-      { label: 'Send on Publish', value: 'send-on-publish' },
-    ],
-    DISABLE_SEND_ON_PUBLISH: [
-      { label: 'Send Now', value: 'send-now' },
-      { label: 'Schedule Send', value: 'schedule-send' },
-      {
-        label: 'Send on Publish (content has already been published or can\'t be published)',
-        value: 'send-on-publish',
-        disabled: true,
-      },
-    ],
   },
 };
 

--- a/src/plugins/notify/constants.js
+++ b/src/plugins/notify/constants.js
@@ -41,7 +41,6 @@ export const formConfigs = {
     SCHEDULE_SEND: 'schedule-send',
     SEND_ON_PUBLISH: 'send-on-publish',
     DISABLE_SEND_NOW: [
-      { label: 'Send Now (content has not been published yet)', value: 'send-now', disabled: true },
       { label: 'Schedule Send', value: 'schedule-send' },
       { label: 'Send on Publish', value: 'send-on-publish' },
     ],


### PR DESCRIPTION
Adjust Notification Send Options To Exclude 'Send Now' On Unpublished Content
