### PR TITLE
map unsupported block types and div elements to paragraph tags in block render config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## v0.7.1
+* Convert unsupported block types to `<p>` tags to preserve line breaks when pasting HTML content into blocksmith.
+
+
 ## v0.7.0
 * Cursor goes to top of content blocks or top of last block when using keyboard arrows to move to the end of the content blocks.
 * Fix formatting of `jwplayer_synced_at`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1518,30 +1518,13 @@
       "dev": true
     },
     "@triniti/acme-schemas": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@triniti/acme-schemas/-/acme-schemas-1.1.6.tgz",
-      "integrity": "sha512-sicGSxot7Xir2b60b6qgJom2y3/kwhP8vrp6tF6ZkxHn4a3JbUdKwqOlq4wfTbqHc6U+y8vJUqzAUzhFteKL2g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@triniti/acme-schemas/-/acme-schemas-1.1.9.tgz",
+      "integrity": "sha512-5F0eoNxfqOPlHwKyro4gsEW17oiPzOBECS3C5suZJwv8KV6Fot8md5VIbq94ggg0UbTk5PA5iuznhyUk6nVKlg==",
       "dev": true,
       "requires": {
-        "@gdbots/schemas": "1.6.5",
-        "@triniti/schemas": "1.1.8"
-      },
-      "dependencies": {
-        "@gdbots/schemas": {
-          "version": "1.6.5",
-          "resolved": "https://registry.npmjs.org/@gdbots/schemas/-/schemas-1.6.5.tgz",
-          "integrity": "sha512-W//vvkERO4kKDUqMz38dED3GHUFqGnjTe2p1fwlzZzKU92mQ+4SkD7XLdDOB2ON+HtXUS4a4VUSoRAGrKfG7ZA==",
-          "dev": true
-        },
-        "@triniti/schemas": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/@triniti/schemas/-/schemas-1.1.8.tgz",
-          "integrity": "sha512-Cl9FmbaenXlER4lQs7qpjEDVjO6MIb4pp7Ux6wPonNIAImptz95PJhCqt/De4KWTx0kNBpu7KgyIPGTv9sAU1Q==",
-          "dev": true,
-          "requires": {
-            "@gdbots/schemas": "^1.6.5"
-          }
-        }
+        "@gdbots/schemas": "1.6.6",
+        "@triniti/schemas": "1.1.11"
       }
     },
     "@triniti/admin-ui-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/cms",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@gdbots/schemas": "^1.6.6",
     "@hot-loader/react-dom": "^16.13.0",
     "@redux-saga/testing-utils": "^1.1.1",
-    "@triniti/acme-schemas": "^1.1.6",
+    "@triniti/acme-schemas": "^1.1.9",
     "@triniti/schemas": "^1.1.11",
     "ajv": "^6.12.2",
     "autoprefixer": "^9.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/cms",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "@triniti/cms is a single page app for managing triniti schemas and services.",
   "license": "Apache-2.0",
   "module": "./index.js",

--- a/src/plugins/blocksmith/components/blocksmith/index.jsx
+++ b/src/plugins/blocksmith/components/blocksmith/index.jsx
@@ -241,7 +241,8 @@ class Blocksmith extends React.Component {
         wrapper: <ul />,
       },
       [blockTypes.UNSTYLED]: {
-        element: 'div',
+        element: 'p',
+        aliasedElements: ['div'],
       },
     });
 


### PR DESCRIPTION
Copying and pasting HTML into blocksmith is stripping out unsupported elements correctly, but it is also getting rid of line breaks, which creates one text block for the whole blob. This code addresses that issue.