### PR TITLE
Count Asset Patched Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## vN.N.N
+* CMS - Uploading assets is throwing an error for some users
+
+
 ## v0.13.1
 * CMS Node Screen must display errors if node fails to load
 * Change Copy/Pasting of text blocks to not copy state of block just text inside it.

--- a/src/plugins/dam/components/batch-edit-modal/delegate.js
+++ b/src/plugins/dam/components/batch-edit-modal/delegate.js
@@ -76,7 +76,7 @@ class Delegate {
       values: fixedKeysCurrentValues,
     };
 
-    this.dispatch(batchEditPatchAssets(data, assetIds, { schemas }));
+    this.dispatch(batchEditPatchAssets(data, assetIds, { schemas, assetCount: assetIds.length }));
     onToggleBatchEdit();
   }
 }

--- a/src/plugins/dam/components/uploader/delegate.js
+++ b/src/plugins/dam/components/uploader/delegate.js
@@ -173,17 +173,17 @@ class Delegate extends AbstractDelegate {
   }
 
   handleCreditApplyAll(credit, files, initialValues) {
-    const assetCount = { assetCount: files.length };
+    const config = { ...this.config, assetCount: Object.keys(files).length };
     const data = {
       fields: ['credit'],
       values: { credit },
     };
     this.dispatch(initialize(this.getFormName(), { ...initialValues, credit }, 'credit'));
-    this.dispatch(patchAssets(data, files, { ...this.config, assetCount }));
+    this.dispatch(patchAssets(data, files, config));
   }
 
   handleExpiresAtApplyAll(expiresAt, files, initialValues) {
-    const assetCount = { assetCount: files.length };
+    const config = { ...this.config, assetCount: Object.keys(files).length };
     const data = {
       fields: ['expires_at'],
       values: { expires_at: expiresAt },
@@ -192,7 +192,7 @@ class Delegate extends AbstractDelegate {
       this.getFormName(),
       { ...initialValues, expiresAt },
     ));
-    this.dispatch(patchAssets(data, files, { ...this.config, assetCount }));
+    this.dispatch(patchAssets(data, files, config));
   }
 
   getFormName() {

--- a/src/plugins/dam/components/uploader/delegate.js
+++ b/src/plugins/dam/components/uploader/delegate.js
@@ -173,15 +173,17 @@ class Delegate extends AbstractDelegate {
   }
 
   handleCreditApplyAll(credit, files, initialValues) {
+    const assetCount = { assetCount: files.length };
     const data = {
       fields: ['credit'],
       values: { credit },
     };
     this.dispatch(initialize(this.getFormName(), { ...initialValues, credit }, 'credit'));
-    this.dispatch(patchAssets(data, files, this.config));
+    this.dispatch(patchAssets(data, files, { ...this.config, assetCount }));
   }
 
   handleExpiresAtApplyAll(expiresAt, files, initialValues) {
+    const assetCount = { assetCount: files.length };
     const data = {
       fields: ['expires_at'],
       values: { expires_at: expiresAt },
@@ -190,7 +192,7 @@ class Delegate extends AbstractDelegate {
       this.getFormName(),
       { ...initialValues, expiresAt },
     ));
-    this.dispatch(patchAssets(data, files, this.config));
+    this.dispatch(patchAssets(data, files, { ...this.config, assetCount }));
   }
 
   getFormName() {

--- a/src/plugins/dam/components/uploader/delegate.js
+++ b/src/plugins/dam/components/uploader/delegate.js
@@ -173,7 +173,7 @@ class Delegate extends AbstractDelegate {
   }
 
   handleCreditApplyAll(credit, files, initialValues) {
-    const config = { ...this.config, assetCount: Object.keys(files).length };
+    const config = { schemas, assetCount: Object.keys(files).length };
     const data = {
       fields: ['credit'],
       values: { credit },
@@ -183,7 +183,7 @@ class Delegate extends AbstractDelegate {
   }
 
   handleExpiresAtApplyAll(expiresAt, files, initialValues) {
-    const config = { ...this.config, assetCount: Object.keys(files).length };
+    const config = { schemas, assetCount: Object.keys(files).length };
     const data = {
       fields: ['expires_at'],
       values: { expires_at: expiresAt },

--- a/src/plugins/dam/sagas/index.js
+++ b/src/plugins/dam/sagas/index.js
@@ -16,9 +16,7 @@ const MAX_FILE_READERS = 10; // This number should be >= MAX_FILE_UPLOADS
 const MAX_FILE_UPLOADS = 3;
 
 function* watchPatchAssets() {
-  yield takeEvery([
-    actionTypes.PATCH_ASSETS_REQUESTED,
-  ], patchAssetsFlow);
+  yield takeLatest(actionTypes.PATCH_ASSETS_REQUESTED, patchAssetsFlow);
 }
 
 function* watchProcessFiles() {

--- a/src/plugins/dam/sagas/patchAssetsFlow.js
+++ b/src/plugins/dam/sagas/patchAssetsFlow.js
@@ -45,13 +45,18 @@ export default function* (action) {
   const expectedEvent = config.schemas.assetPatched.getCurie().toString();
 
   try {
+    const assetCount = pbj.get('node_refs', []).length;
+    let timeout = 5000;
+    if (assetCount && assetCount > 2) {
+      timeout += (500 * (assetCount - 2));
+    }
     const eventChannel = yield actionChannel(expectedEvent);
     yield fork([toast, 'show']);
     yield putResolve(pbj);
 
     const result = yield race({
-      event: call(waitForMyEvent, eventChannel),
-      timeout: delay(5000),
+      event: call(waitForMyEvent, eventChannel, assetCount),
+      timeout: delay(timeout),
     });
 
     if (result.timeout) {

--- a/src/plugins/dam/sagas/patchAssetsFlow.js
+++ b/src/plugins/dam/sagas/patchAssetsFlow.js
@@ -45,17 +45,16 @@ export default function* (action) {
   const expectedEvent = config.schemas.assetPatched.getCurie().toString();
 
   try {
-    const assetCount = pbj.get('node_refs', []).length;
     let timeout = 5000;
-    if (assetCount && assetCount > 2) {
-      timeout += (500 * (assetCount - 2));
+    if (config.assetCount && config.assetCount > 10) {
+      timeout += (500 * (config.assetCount - 10));
     }
     const eventChannel = yield actionChannel(expectedEvent);
     yield fork([toast, 'show']);
     yield putResolve(pbj);
 
     const result = yield race({
-      event: call(waitForMyEvent, eventChannel, assetCount),
+      event: call(waitForMyEvent, eventChannel, config.assetCount),
       timeout: delay(timeout),
     });
 


### PR DESCRIPTION
Count Raven's `Asset Patched` events and compare to the actual count of assets processed for patching. This update is patterned here - https://github.com/triniti/cms-js/blob/master/src/plugins/dam/sagas/reorderGalleryAssetsFlow.js