### PR TITLE
Uploader Component Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## vN.N.N
+* CMS - Uploading assets is throwing an error for some users
+
+
 ## v0.13.1
 * CMS Node Screen must display errors if node fails to load
 * Change Copy/Pasting of text blocks to not copy state of block just text inside it.

--- a/src/plugins/dam/components/batch-edit-modal/delegate.js
+++ b/src/plugins/dam/components/batch-edit-modal/delegate.js
@@ -76,7 +76,7 @@ class Delegate {
       values: fixedKeysCurrentValues,
     };
 
-    this.dispatch(batchEditPatchAssets(data, assetIds, { schemas }));
+    this.dispatch(batchEditPatchAssets(data, assetIds, { schemas, assetCount: assetIds.length }));
     onToggleBatchEdit();
   }
 }

--- a/src/plugins/dam/components/uploader-asset-fields/index.jsx
+++ b/src/plugins/dam/components/uploader-asset-fields/index.jsx
@@ -17,7 +17,7 @@ export default class UploaderAssetFields extends React.Component {
   static propTypes = {
     activeHashName: PropTypes.string.isRequired,
     currentValues: PropTypes.shape({
-      credit: PropTypes.object,
+      credit: PropTypes.shape({}),
       expiresAt: PropTypes.instanceOf(Date),
     }),
     enableCreditApplyAll: PropTypes.bool,
@@ -51,7 +51,8 @@ export default class UploaderAssetFields extends React.Component {
       initialValues,
       currentValues,
     } = this.props;
-    onCreditApplyToAll(currentValues.credit.value, files, initialValues);
+    const validFiles = Object.fromEntries(Object.entries(files).filter(([, file]) => !file.error));
+    onCreditApplyToAll(currentValues.credit.value, validFiles, initialValues);
   }
 
   handleExpiresAtApplyToAll() {
@@ -61,7 +62,8 @@ export default class UploaderAssetFields extends React.Component {
       initialValues,
       currentValues,
     } = this.props;
-    onExpiresAtApplyToAll(currentValues.expiresAt || null, files, initialValues);
+    const validFiles = Object.fromEntries(Object.entries(files).filter(([, file]) => !file.error));
+    onExpiresAtApplyToAll(currentValues.expiresAt || null, validFiles, initialValues);
   }
 
   render() {

--- a/src/plugins/dam/components/uploader-asset-fields/index.jsx
+++ b/src/plugins/dam/components/uploader-asset-fields/index.jsx
@@ -22,11 +22,12 @@ export default class UploaderAssetFields extends React.Component {
     }),
     enableCreditApplyAll: PropTypes.bool,
     enableExpirationDateApplyAll: PropTypes.bool,
-    files: PropTypes.shape({}).isRequired,
+    files: PropTypes.shape({ hashName: PropTypes.shape({}) }).isRequired,
     onCreditApplyToAll: PropTypes.func,
     onExpiresAtApplyToAll: PropTypes.func,
     hasMultipleFiles: PropTypes.bool,
     initialValues: PropTypes.shape({}).isRequired,
+    uploadedFiles: PropTypes.shape({ hashName: PropTypes.shape({}) }).isRequired,
   };
 
   static defaultProps = {
@@ -47,23 +48,21 @@ export default class UploaderAssetFields extends React.Component {
   handleCreditApplyToAll() {
     const {
       onCreditApplyToAll,
-      files,
       initialValues,
       currentValues,
+      uploadedFiles,
     } = this.props;
-    const validFiles = Object.fromEntries(Object.entries(files).filter(([, file]) => !file.error));
-    onCreditApplyToAll(currentValues.credit.value, validFiles, initialValues);
+    onCreditApplyToAll((currentValues.credit || {}).value, uploadedFiles, initialValues);
   }
 
   handleExpiresAtApplyToAll() {
     const {
       onExpiresAtApplyToAll,
-      files,
       initialValues,
       currentValues,
+      uploadedFiles,
     } = this.props;
-    const validFiles = Object.fromEntries(Object.entries(files).filter(([, file]) => !file.error));
-    onExpiresAtApplyToAll(currentValues.expiresAt || null, validFiles, initialValues);
+    onExpiresAtApplyToAll(currentValues.expiresAt || null, uploadedFiles, initialValues);
   }
 
   render() {

--- a/src/plugins/dam/components/uploader/Uploader.jsx
+++ b/src/plugins/dam/components/uploader/Uploader.jsx
@@ -59,6 +59,7 @@ class Uploader extends React.Component {
     /* eslint react/no-unused-prop-types: off */
     onClose: PropTypes.func, // This is used in the delegate
     onToggleUploader: PropTypes.func.isRequired,
+    uploadedFiles: PropTypes.shape({ hashName: PropTypes.shape({}) }),
   };
 
   static defaultProps = {
@@ -78,6 +79,7 @@ class Uploader extends React.Component {
     mimeTypeErrorMessage: 'Invalid Action: Trying to upload invalid file type.',
     multiAssetErrorMessage: 'Invalid Action: Trying to upload multiple assets.',
     onClose: noop,
+    uploadedFiles: {},
   };
 
   constructor(props) {
@@ -153,6 +155,7 @@ class Uploader extends React.Component {
       isFormDirty,
       isOpen,
       files,
+      uploadedFiles,
     } = this.props;
 
     return (
@@ -205,6 +208,7 @@ class Uploader extends React.Component {
                           warn={delegate.handleWarn}
                           onSave={delegate.handleSave}
                           onSubmit={delegate.handleSubmit}
+                          uploadedFiles={uploadedFiles}
                         />
                       )}
                     {activeHashName && !activeAsset && <h3>Processing...</h3>}

--- a/src/plugins/dam/components/uploader/Uploader.jsx
+++ b/src/plugins/dam/components/uploader/Uploader.jsx
@@ -47,12 +47,11 @@ class Uploader extends React.Component {
     delegate: PropTypes.instanceOf(Delegate).isRequired,
     enableCreditApplyAll: PropTypes.bool,
     enableExpirationDateApplyAll: PropTypes.bool,
-    files: PropTypes.shape({ hashName: PropTypes.object }).isRequired,
+    enableSaveChanges: PropTypes.bool,
+    files: PropTypes.shape({ hashName: PropTypes.shape({}) }).isRequired,
     hasFilesProcessing: PropTypes.bool,
     hasMultipleFiles: PropTypes.bool,
     isFormDirty: PropTypes.bool,
-    isFormPrestine: PropTypes.bool,
-    isFormValid: PropTypes.bool,
     isOpen: PropTypes.bool,
     lastGallerySequence: PropTypes.number,
     mimeTypeErrorMessage: PropTypes.string,
@@ -70,11 +69,10 @@ class Uploader extends React.Component {
     currentValues: {},
     enableCreditApplyAll: false,
     enableExpirationDateApplyAll: false,
+    enableSaveChanges: false,
     hasFilesProcessing: false,
     hasMultipleFiles: false,
-    isFormDirty: undefined,
-    isFormPrestine: undefined,
-    isFormValid: undefined,
+    isFormDirty: false,
     isOpen: false,
     lastGallerySequence: 0,
     mimeTypeErrorMessage: 'Invalid Action: Trying to upload invalid file type.',
@@ -149,11 +147,10 @@ class Uploader extends React.Component {
       currentValues,
       enableCreditApplyAll,
       enableExpirationDateApplyAll,
+      enableSaveChanges,
       hasFilesProcessing,
       hasMultipleFiles,
       isFormDirty,
-      isFormValid,
-      isFormPrestine,
       isOpen,
       files,
     } = this.props;
@@ -231,7 +228,7 @@ class Uploader extends React.Component {
                   <div>
                     <Button
                       onClick={delegate.handleSave}
-                      disabled={isFormValid && !isFormDirty && !isFormPrestine}
+                      disabled={!enableSaveChanges}
                     >
                       Save Changes
                     </Button>

--- a/src/plugins/dam/components/uploader/delegate.js
+++ b/src/plugins/dam/components/uploader/delegate.js
@@ -173,17 +173,17 @@ class Delegate extends AbstractDelegate {
   }
 
   handleCreditApplyAll(credit, files, initialValues) {
-    const assetCount = { assetCount: files.length };
+    const config = { ...this.config, assetCount: Object.keys(files).length };
     const data = {
       fields: ['credit'],
       values: { credit },
     };
     this.dispatch(initialize(this.getFormName(), { ...initialValues, credit }, 'credit'));
-    this.dispatch(patchAssets(data, files, { ...this.config, assetCount }));
+    this.dispatch(patchAssets(data, files, config));
   }
 
   handleExpiresAtApplyAll(expiresAt, files, initialValues) {
-    const assetCount = { assetCount: files.length };
+    const config = { ...this.config, assetCount: Object.keys(files).length };
     const data = {
       fields: ['expires_at'],
       values: { expires_at: expiresAt },
@@ -192,7 +192,7 @@ class Delegate extends AbstractDelegate {
       this.getFormName(),
       { ...initialValues, expiresAt },
     ));
-    this.dispatch(patchAssets(data, files, { ...this.config, assetCount }));
+    this.dispatch(patchAssets(data, files, config));
   }
 
   getFormName() {

--- a/src/plugins/dam/components/uploader/delegate.js
+++ b/src/plugins/dam/components/uploader/delegate.js
@@ -178,7 +178,11 @@ class Delegate extends AbstractDelegate {
       fields: ['credit'],
       values: { credit },
     };
-    this.dispatch(initialize(this.getFormName(), { ...initialValues, credit }, 'credit'));
+    this.dispatch(initialize(
+      this.getFormName(),
+      { ...initialValues, credit: { value: credit } },
+      'credit',
+    ));
     this.dispatch(patchAssets(data, files, config));
   }
 

--- a/src/plugins/dam/components/uploader/delegate.js
+++ b/src/plugins/dam/components/uploader/delegate.js
@@ -173,15 +173,17 @@ class Delegate extends AbstractDelegate {
   }
 
   handleCreditApplyAll(credit, files, initialValues) {
+    const assetCount = { assetCount: files.length };
     const data = {
       fields: ['credit'],
       values: { credit },
     };
     this.dispatch(initialize(this.getFormName(), { ...initialValues, credit }, 'credit'));
-    this.dispatch(patchAssets(data, files, this.config));
+    this.dispatch(patchAssets(data, files, { ...this.config, assetCount }));
   }
 
   handleExpiresAtApplyAll(expiresAt, files, initialValues) {
+    const assetCount = { assetCount: files.length };
     const data = {
       fields: ['expires_at'],
       values: { expires_at: expiresAt },
@@ -190,7 +192,7 @@ class Delegate extends AbstractDelegate {
       this.getFormName(),
       { ...initialValues, expiresAt },
     ));
-    this.dispatch(patchAssets(data, files, this.config));
+    this.dispatch(patchAssets(data, files, { ...this.config, assetCount }));
   }
 
   getFormName() {

--- a/src/plugins/dam/components/uploader/delegate.js
+++ b/src/plugins/dam/components/uploader/delegate.js
@@ -173,7 +173,7 @@ class Delegate extends AbstractDelegate {
   }
 
   handleCreditApplyAll(credit, files, initialValues) {
-    const config = { ...this.config, assetCount: Object.keys(files).length };
+    const config = { schemas, assetCount: Object.keys(files).length };
     const data = {
       fields: ['credit'],
       values: { credit },
@@ -183,7 +183,7 @@ class Delegate extends AbstractDelegate {
   }
 
   handleExpiresAtApplyAll(expiresAt, files, initialValues) {
-    const config = { ...this.config, assetCount: Object.keys(files).length };
+    const config = { schemas, assetCount: Object.keys(files).length };
     const data = {
       fields: ['expires_at'],
       values: { expires_at: expiresAt },

--- a/src/plugins/dam/components/uploader/selector.js
+++ b/src/plugins/dam/components/uploader/selector.js
@@ -45,37 +45,14 @@ export default (state) => {
   const hasFilesProcessing = filesProcessing.length > 0;
   const hasMultipleFiles = Object.keys(files).length > 1;
   const isActiveFileProcessing = !!filesProcessing.find((file) => file.hashName === activeHashName);
-  const isActiveFileValid = activeHashName && !files[activeHashName].error;
-  const enableCreditApplyAll = isActiveFileValid
-    && !isActiveFileProcessing
-    && isFormDirty
+  const isActiveFileValid = activeHashName !== null && !files[activeHashName].error;
+  const enableSaveChanges = isActiveFileValid && !isActiveFileProcessing && isFormDirty;
+  const enableCreditApplyAll = enableSaveChanges
     && get(initialValues, 'credit.value') !== get(currentValues, 'credit.value');
+  const enableExpirationDateApplyAll = enableSaveChanges
+    && !areDatesEqual(initialValues.expiresAt, currentValues.expiresAt);
   const alerts = getAlerts(state, formName);
   const sequence = getCounter(state, utilityTypes.GALLERY_SEQUENCE_COUNTER);
-  const enableExpirationDateApplyAll = (() => {
-    if (!isActiveFileValid) {
-      return false;
-    }
-
-    if (isActiveFileProcessing) {
-      return false;
-    }
-
-    if (!isFormDirty) {
-      return false;
-    }
-
-    if (!initialValues.expiresAt && currentValues.expiresAt) {
-      return true;
-    }
-
-    if (initialValues.expiresAt) {
-      return !areDatesEqual(initialValues.expiresAt, currentValues.expiresAt);
-    }
-
-    return true;
-  })();
-  const enableSaveChanges = isActiveFileValid && !isActiveFileProcessing && isFormDirty;
   const uploadedFiles = Object.fromEntries(Object.entries(files)
     .filter(([, file]) => !file.error && file.status === fileUploadStatuses.COMPLETED));
 

--- a/src/plugins/dam/components/uploader/selector.test.js
+++ b/src/plugins/dam/components/uploader/selector.test.js
@@ -1,0 +1,484 @@
+import test from 'tape';
+
+import selector from './selector';
+import { formNames, fileUploadStatuses } from '../../constants';
+
+// mock an initial form data
+const initialTitle = 'title1';
+const initialCredit = 'credit1';
+const initialExpiresAt = new Date('December 17, 2020 03:24:00');
+const initialFormData = {
+  initial: {
+    title: initialTitle,
+    credit: {
+      value: initialCredit,
+    },
+    expiresAt: initialExpiresAt,
+  },
+};
+
+const mockFormState = (activeHashName = 'file1', formData = {}) => {
+  const formName = `${formNames.UPLOADER_FORM_PREFIX}${activeHashName}`;
+  const form = {
+    [formName]: formData,
+  };
+  return { form };
+};
+
+const mockDamState = (files = {}) => {
+  const dam = {
+    uploader: {
+      files,
+    },
+  };
+  return { dam };
+};
+
+const mockRest = () => {
+  const adminUi = {
+    alerts: [],
+  };
+  const utils = {
+    counters: {},
+  };
+  return { adminUi, utils };
+};
+
+const mockDamFiles = (activeHashName, files = {}) => {
+  const clonedFiles = { ...files };
+  const activeFile = clonedFiles[activeHashName];
+  if (activeFile) {
+    activeFile.active = true;
+  }
+  return clonedFiles;
+};
+
+/**
+ * assuming form is dirty, ff. tests ensure that:
+ * 1. ONLY uploaded files are submitted for update/patch process
+ * 2. save/patch buttons remain DISABLED if NO active item
+ * 3. save/patch buttons remain DISABLED if active item has an error
+ * 4. save/patch buttons remain DISABLED if active item is still in upload process
+ * 4. save/patch buttons is ONLY ENABLED if active item is truly uploaded
+ */
+
+test('Uploader selector - initial', (t) => {
+  const files = {};
+  const mockState = {
+    ...mockFormState(),
+    ...mockDamState(files),
+    ...mockRest(),
+  };
+  const {
+    activeHashName,
+    enableCreditApplyAll,
+    enableExpirationDateApplyAll,
+    enableSaveChanges,
+    uploadedFiles,
+  } = selector(mockState);
+
+  let actual = activeHashName;
+  let expected = null;
+  t.equal(actual, expected, 'it should have no active file');
+
+  actual = enableCreditApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `credit apply all` button');
+
+  actual = enableExpirationDateApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `exp. date apply all` button');
+
+  actual = enableSaveChanges;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `save changes` button');
+
+  actual = Object.keys(uploadedFiles).length;
+  expected = 0;
+  t.equal(actual, expected, 'it should have no uploaded files');
+
+  t.end();
+});
+
+test('Uploader selector - no uploaded files', (t) => {
+  const activeFile = 'file3';
+  const files = {
+    file1: {
+      status: fileUploadStatuses.PROCESSING,
+      error: false,
+    },
+    file2: {
+      status: fileUploadStatuses.PROCESSING,
+      error: false,
+    },
+    file3: {
+      status: fileUploadStatuses.ERROR,
+      error: new Error('error'),
+    },
+  };
+
+  const dirtyFormData = { ...initialFormData,
+    values: {
+      title: 'title2',
+      credit: {
+        value: 'credit2',
+      },
+      expiresAt: new Date('December 17, 2021 03:24:00'),
+    } };
+
+  const mockState = {
+    ...mockFormState(activeFile, dirtyFormData),
+    ...mockDamState(mockDamFiles(activeFile, files)),
+    ...mockRest(),
+  };
+  const {
+    activeHashName,
+    enableCreditApplyAll,
+    enableExpirationDateApplyAll,
+    enableSaveChanges,
+    uploadedFiles,
+  } = selector(mockState);
+
+  let actual = activeHashName;
+  let expected = activeFile;
+  t.equal(actual, expected, 'it should have an active file');
+
+  actual = enableCreditApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `credit apply all` button');
+
+  actual = enableExpirationDateApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `exp. date apply all` button');
+
+  actual = enableSaveChanges;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `save changes` button');
+
+  actual = Object.keys(uploadedFiles).length;
+  expected = 0;
+  t.equal(actual, expected, 'it should have no uploaded files');
+
+  t.end();
+});
+
+
+test('Uploader selector - all files successfully uploaded', (t) => {
+  const activeFile = 'file2';
+  const files = {
+    file1: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+    file2: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+    file3: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+  };
+
+  // only title and expiresAt are updated
+  const dirtyFormData = { ...initialFormData,
+    values: {
+      title: 'title2',
+      credit: {
+        value: initialCredit,
+      },
+      expiresAt: new Date('December 17, 2021 03:24:00'),
+    } };
+
+  const mockState = {
+    ...mockFormState(activeFile, dirtyFormData),
+    ...mockDamState(mockDamFiles(activeFile, files)),
+    ...mockRest(),
+  };
+  const {
+    activeHashName,
+    enableCreditApplyAll,
+    enableExpirationDateApplyAll,
+    enableSaveChanges,
+    uploadedFiles,
+  } = selector(mockState);
+
+  let actual = activeHashName;
+  let expected = activeFile;
+  t.equal(actual, expected, 'it should have an active file');
+
+  actual = enableCreditApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `credit apply all` button');
+
+  actual = enableExpirationDateApplyAll;
+  expected = true;
+  t.equal(actual, expected, 'it should enable `exp. date apply all` button');
+
+  actual = enableSaveChanges;
+  expected = true;
+  t.equal(actual, expected, 'it should enable `save changes` button');
+
+  actual = Object.keys(uploadedFiles).length;
+  expected = Object.keys(files).length;
+  t.equal(actual, expected, 'it should have correct count of uploaded files');
+
+  t.end();
+});
+
+test('Uploader selector - files successfully uploaded [only title field updated]', (t) => {
+  const activeFile = 'file3';
+  const files = {
+    file1: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+    file2: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+    file3: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+  };
+
+  // only title field is updated
+  const dirtyFormData = { ...initialFormData,
+    values: {
+      title: 'title2',
+      credit: {
+        value: initialCredit,
+      },
+      expiresAt: initialExpiresAt,
+    } };
+
+  const mockState = {
+    ...mockFormState(activeFile, dirtyFormData),
+    ...mockDamState(mockDamFiles(activeFile, files)),
+    ...mockRest(),
+  };
+  const {
+    activeHashName,
+    enableCreditApplyAll,
+    enableExpirationDateApplyAll,
+    enableSaveChanges,
+    uploadedFiles,
+  } = selector(mockState);
+
+  let actual = activeHashName;
+  let expected = activeFile;
+  t.equal(actual, expected, 'it should have an active file');
+
+  actual = enableCreditApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `credit apply all` button');
+
+  actual = enableExpirationDateApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `exp. date apply all` button');
+
+  actual = enableSaveChanges;
+  expected = true;
+  t.equal(actual, expected, 'it should enable `save changes` button');
+
+  actual = Object.keys(uploadedFiles).length;
+  expected = Object.keys(files).length;
+  t.equal(actual, expected, 'it should have correct count of uploaded files');
+
+  t.end();
+});
+
+test('Uploader selector - files successfully uploaded but no active file', (t) => {
+  const activeFile = undefined;
+  const files = {
+    file1: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+    file2: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+    file3: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+  };
+
+  const dirtyFormData = { ...initialFormData,
+    values: {
+      title: 'title2',
+      credit: {
+        value: 'credit2',
+      },
+      expiresAt: new Date('December 17, 2022 03:24:00'),
+    } };
+
+  const mockState = {
+    ...mockFormState(activeFile, dirtyFormData),
+    ...mockDamState(mockDamFiles(activeFile, files)),
+    ...mockRest(),
+  };
+  const {
+    activeHashName,
+    enableCreditApplyAll,
+    enableExpirationDateApplyAll,
+    enableSaveChanges,
+    uploadedFiles,
+  } = selector(mockState);
+
+  let actual = activeHashName;
+  let expected = null;
+  t.equal(actual, expected, 'it should have no active file');
+
+  actual = enableCreditApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `credit apply all` button');
+
+  actual = enableExpirationDateApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `exp. date apply all` button');
+
+  actual = enableSaveChanges;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `save changes` button');
+
+  actual = Object.keys(uploadedFiles).length;
+  expected = Object.keys(files).length;
+  t.equal(actual, expected, 'it should have correct count of uploaded files');
+
+  t.end();
+});
+
+test('Uploader selector - all files uploaded except active file', (t) => {
+  const activeFile = 'file2';
+  const files = {
+    file1: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+    // mock an active file that has error
+    file2: {
+      status: fileUploadStatuses.ERROR,
+      error: new Error('error'),
+    },
+    file3: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+    file4: {
+      status: fileUploadStatuses.COMPLETED,
+    },
+  };
+
+  const dirtyFormData = { ...initialFormData,
+    values: {
+      title: 'title2',
+      credit: {
+        value: 'credit2',
+      },
+      expiresAt: new Date('December 17, 2021 03:24:00'),
+    } };
+
+  const mockState = {
+    ...mockFormState(activeFile, dirtyFormData),
+    ...mockDamState(mockDamFiles(activeFile, files)),
+    ...mockRest(),
+  };
+  const {
+    activeHashName,
+    enableCreditApplyAll,
+    enableExpirationDateApplyAll,
+    enableSaveChanges,
+    uploadedFiles,
+  } = selector(mockState);
+
+  let actual = activeHashName;
+  let expected = activeFile;
+  t.equal(actual, expected, 'it should have an active file');
+
+  actual = enableCreditApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `credit apply all` button');
+
+  actual = enableExpirationDateApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `exp. date apply all` button');
+
+  actual = enableSaveChanges;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `save changes` button');
+
+  actual = Object.keys(uploadedFiles).length;
+  expected = Object.values(files).filter(({ error, status }) => !error && status === fileUploadStatuses.COMPLETED).length;
+  t.equal(actual, expected, 'it should have correct count of uploaded files');
+
+  t.end();
+});
+
+test('Uploader selector - all files NOT uploaded except active file', (t) => {
+  const activeFile = 'file2';
+  const files = {
+    file1: {
+      status: fileUploadStatuses.ERROR,
+      error: new Error('error'),
+    },
+    // mock an active file that is uploaded
+    file2: {
+      status: fileUploadStatuses.COMPLETED,
+      error: false,
+    },
+    file3: {
+      status: fileUploadStatuses.ERROR,
+      error: new Error('error'),
+    },
+    file4: {
+      status: fileUploadStatuses.ERROR,
+      error: new Error('error'),
+    },
+  };
+
+  const dirtyFormData = { ...initialFormData,
+    values: {
+      title: 'title2',
+      credit: {
+        value: initialCredit,
+      },
+    } };
+
+  const mockState = {
+    ...mockFormState(activeFile, dirtyFormData),
+    ...mockDamState(mockDamFiles(activeFile, files)),
+    ...mockRest(),
+  };
+  const {
+    activeHashName,
+    enableCreditApplyAll,
+    enableExpirationDateApplyAll,
+    enableSaveChanges,
+    uploadedFiles,
+  } = selector(mockState);
+
+  let actual = activeHashName;
+  let expected = activeFile;
+  t.equal(actual, expected, 'it should have an active file');
+
+  actual = enableCreditApplyAll;
+  expected = false;
+  t.equal(actual, expected, 'it should disable `credit apply all` button');
+
+  actual = enableExpirationDateApplyAll;
+  expected = true;
+  t.equal(actual, expected, 'it should enable `exp. date apply all` button');
+
+  actual = enableSaveChanges;
+  expected = true;
+  t.equal(actual, expected, 'it should enable `save changes` button');
+
+  actual = Object.keys(uploadedFiles).length;
+  expected = Object.values(files).filter(({ error, status }) => !error && status === fileUploadStatuses.COMPLETED).length;
+  t.equal(actual, expected, 'it should have correct count of uploaded files');
+
+  t.end();
+});

--- a/src/plugins/dam/sagas/index.js
+++ b/src/plugins/dam/sagas/index.js
@@ -16,9 +16,7 @@ const MAX_FILE_READERS = 10; // This number should be >= MAX_FILE_UPLOADS
 const MAX_FILE_UPLOADS = 3;
 
 function* watchPatchAssets() {
-  yield takeEvery([
-    actionTypes.PATCH_ASSETS_REQUESTED,
-  ], patchAssetsFlow);
+  yield takeLatest(actionTypes.PATCH_ASSETS_REQUESTED, patchAssetsFlow);
 }
 
 function* watchProcessFiles() {

--- a/src/plugins/dam/sagas/patchAssetsFlow.js
+++ b/src/plugins/dam/sagas/patchAssetsFlow.js
@@ -45,13 +45,18 @@ export default function* (action) {
   const expectedEvent = config.schemas.assetPatched.getCurie().toString();
 
   try {
+    const assetCount = pbj.get('node_refs', []).length;
+    let timeout = 5000;
+    if (assetCount && assetCount > 2) {
+      timeout += (500 * (assetCount - 2));
+    }
     const eventChannel = yield actionChannel(expectedEvent);
     yield fork([toast, 'show']);
     yield putResolve(pbj);
 
     const result = yield race({
-      event: call(waitForMyEvent, eventChannel),
-      timeout: delay(5000),
+      event: call(waitForMyEvent, eventChannel, assetCount),
+      timeout: delay(timeout),
     });
 
     if (result.timeout) {

--- a/src/plugins/dam/sagas/patchAssetsFlow.js
+++ b/src/plugins/dam/sagas/patchAssetsFlow.js
@@ -45,17 +45,16 @@ export default function* (action) {
   const expectedEvent = config.schemas.assetPatched.getCurie().toString();
 
   try {
-    const assetCount = pbj.get('node_refs', []).length;
     let timeout = 5000;
-    if (assetCount && assetCount > 2) {
-      timeout += (500 * (assetCount - 2));
+    if (config.assetCount && config.assetCount > 10) {
+      timeout += (500 * (config.assetCount - 10));
     }
     const eventChannel = yield actionChannel(expectedEvent);
     yield fork([toast, 'show']);
     yield putResolve(pbj);
 
     const result = yield race({
-      event: call(waitForMyEvent, eventChannel, assetCount),
+      event: call(waitForMyEvent, eventChannel, config.assetCount),
       timeout: delay(timeout),
     });
 


### PR DESCRIPTION
1. fix issue when user tries to update a file while it is being uploaded.
2. fix issue when user tries to update a file that has an upload error.
3. limit update/patch process to completely uploaded files ONLY.
4. exactly compare count of patched files to Raven's dispatched 'asset-patched' action.
5. fix warning that occurs when clicking for the first time the credit's `apply to all` button.