### PR TITLE
Customizable bs sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 
+## vN.N.N
+* Updating blocksmith sidebar to allow for complete customization of buttons.
+
 ## v0.17.0
 * Fix bug that doesn't register proper text-block updates.
 * Update nvmrc to 14.18.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 
-## v0.18.0
+## vN.N.N
 * Updating blocksmith sidebar to allow for complete customization of buttons.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
 
-## vN.N.N
+## v0.18.0
 * Updating blocksmith sidebar to allow for complete customization of buttons.
+
 
 ## v0.17.0
 * Fix bug that doesn't register proper text-block updates.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/cms",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "@triniti/cms is a single page app for managing triniti schemas and services.",
   "license": "Apache-2.0",
   "module": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/cms",
-  "version": "0.18.0",
+  "version": "0.17.0",
   "description": "@triniti/cms is a single page app for managing triniti schemas and services.",
   "license": "Apache-2.0",
   "module": "./index.js",

--- a/src/plugins/blocksmith/components/generic-sidebar-button/README.md
+++ b/src/plugins/blocksmith/components/generic-sidebar-button/README.md
@@ -5,7 +5,6 @@ This is used to render buttons inside the Blocksmith sidebar popover (in `@trini
 ### Required Props
 + `message`      - A message obtained from `schema.getCurie().getMessage()` eg `image-block`.
 + `onClick`      - What happens when the button is clicked. Usually this opens that block's modal, except the text-block button, which simply inserts a new empty text block (with Blocksmith's `handleHoverInsert` which is passed to the Sidebar as the `onHoverInsert` prop).
-+ `replaceRegEx` - From the sidebar config, this alters the `message` prop to be a more human-friendly label.
 
 ### Optional Props
 + `config`       - An object to inform the component on how to render. Either a single icon, double icons for IconGroup, or a component. Although this is technically optional, you will want to provide it; the default is insufficient.

--- a/src/plugins/blocksmith/components/generic-sidebar-button/index.jsx
+++ b/src/plugins/blocksmith/components/generic-sidebar-button/index.jsx
@@ -7,7 +7,6 @@ const GenericSidebarButton = ({
   config,
   message,
   onClick: handleClick,
-  replaceRegEx,
 }) => (
   <div role="presentation" onMouseDown={(e) => e.preventDefault()}>
     <Button outline onClick={handleClick}>
@@ -49,7 +48,7 @@ const GenericSidebarButton = ({
           ),
         ]}
       </span>
-      <span> { message.replace(replaceRegEx, '').replace(/(-|\s+)/g, ' ') } </span>
+      <span> { message.replace(/-block$/, '').replace(/(-|\s+)/g, ' ') } </span>
     </Button>
   </div>
 );
@@ -81,7 +80,6 @@ GenericSidebarButton.propTypes = {
   ]),
   message: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
-  replaceRegEx: PropTypes.instanceOf(RegExp).isRequired,
 };
 
 GenericSidebarButton.defaultProps = {

--- a/src/plugins/blocksmith/components/sidebar/config.js
+++ b/src/plugins/blocksmith/components/sidebar/config.js
@@ -1,8 +1,9 @@
+/* globals APP_VENDOR */
 export default {
   enableOther: true,
   groups: [
     {
-      header: 'Triniti',
+      header: APP_VENDOR,
       buttons: [
         'article-block',
         'audio-block',

--- a/src/plugins/blocksmith/components/sidebar/config.js
+++ b/src/plugins/blocksmith/components/sidebar/config.js
@@ -1,42 +1,32 @@
-const vendorButtonTypes = [
-  'article-block',
-  'audio-block',
-  'divider-block',
-  'document-block',
-  'gallery-block',
-  'heading-block',
-  'image-block',
-  'page-break-block',
-  'poll-block',
-  'poll-grid-block',
-  'quote-block',
-  'text-block',
-  'video-block',
-];
-
-export { vendorButtonTypes };
-
-/**
- * Config for how the sidebar buttons are displayed/organized/made searchable
- *
- *   - header will be a string in the PopoverHeader
- *   - matchRegEx is what to match in the schema message
- *   - doesMatch is whether you want to match or exclude schemas based on the matchRegEx (this
- *       could also be accomplished with a negative lookahead in matchRegEx, but this seems
- *       easier to work with)
- *   - replaceRegEx is what to replace in the button's text
- */
-export default [
-  {
-    header: 'Social',
-    matchRegEx: new RegExp('(twitter|facebook|instagram)'),
-    doesMatch: true,
-    replaceRegEx: new RegExp('(block)', 'g'),
-  },
-  {
-    header: 'Other',
-    matchRegEx: new RegExp(`(twitter|facebook|instagram|^(${vendorButtonTypes.join('|')}))`),
-    doesMatch: false,
-    replaceRegEx: new RegExp('block', 'g'),
-  },
-];
+export default {
+  enableOther: true,
+  groups: [
+    {
+      header: 'Triniti',
+      buttons: [
+        'article-block',
+        'audio-block',
+        'divider-block',
+        'document-block',
+        'gallery-block',
+        'heading-block',
+        'image-block',
+        'page-break-block',
+        'poll-block',
+        'poll-grid-block',
+        'quote-block',
+        'text-block',
+        'video-block'
+      ]
+    },
+    {
+      header: 'Social',
+      buttons: [
+        'twitter-tweet-block',
+        'facebook-post-block',
+        'facebook-video-block',
+        'instagram-media-block'
+      ]
+    }
+  ],
+};

--- a/src/plugins/blocksmith/components/sidebar/config.js
+++ b/src/plugins/blocksmith/components/sidebar/config.js
@@ -16,8 +16,8 @@ export default {
         'poll-grid-block',
         'quote-block',
         'text-block',
-        'video-block'
-      ]
+        'video-block',
+      ],
     },
     {
       header: 'Social',
@@ -25,8 +25,8 @@ export default {
         'twitter-tweet-block',
         'facebook-post-block',
         'facebook-video-block',
-        'instagram-media-block'
-      ]
-    }
+        'instagram-media-block',
+      ],
+    },
   ],
 };


### PR DESCRIPTION
These updates to the blocksmith sidebar allow for further customization of the button groups.

- Button groups may be placed anywhere (eg: above vendor group).
- Buttons can be listed in any order.
- Vendor button group can be deleted.
- Other group can be turned off.

In addition, the search was modified a tad. Buttons can be placed in multiple groups thus have duplicates. This is nice for the default sidebar view but no need to have duplicates when searching. The search results will list all buttons alphabetically and dedupe them.

Note: This is a breaking change as previous sidebar configs are no longer compatible. 