### PR TITLE
fixing drag

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,7 +2,7 @@
 
 
 ## vN.N.N
-* blocksmith :: hide drag handle during text-selection drag to prevent it from collapsing the browser's native selection focus.
+* blocksmith :: scope text-selection drag guard to editable text so non-text blocks (image, gallery, divider, etc.) stay grab-and-droppable from anywhere on the block.
 * blocksmith :: Add `AppPlugins` extension point for app-level Lexical plugins.
 * ncr :: Slug rename modal - apply slug normalization on blur instead of on every keystroke to prevent cursor jumping when typing in the middle of the slug.
 * NCR MultiSelectField :: Preserve dropdown results after selection in input fields.

--- a/src/blocksmith/plugins/DraggableBlockPlugin.js
+++ b/src/blocksmith/plugins/DraggableBlockPlugin.js
@@ -228,6 +228,12 @@ export default function DraggableBlockPlugin({ anchorElem, onDragStart = noop, o
       if (!isHTMLElement(target) || isOnMenu(target)) {
         return;
       }
+      // Only guard against selection focus theft when mousedown lands in editable
+      // text. Decorator blocks render as contenteditable=false, so grabbing one
+      // should leave the flag clear and let native browser dragstart proceed.
+      if (!target.isContentEditable) {
+        return;
+      }
       isSelectingTextRef.current = true;
     };
 


### PR DESCRIPTION
blocksmith :: scope text-selection drag guard to editable text so non-text blocks (image, gallery, divider, etc.) stay grab-and-droppable from anywhere on the block.