### PR TITLE
Updates to apple new modal

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,7 @@
 
 
 ## vN.N.N
+* Polish apple news modal
 * iam :: Auto-reload on expired auth outside edit screens. Keep "Authentication Required" modal only in edit mode so in-progress work isn't lost.
 * deps :: Pin `final-form` to `5.0.0`, `final-form-arrays` to `4.0.0`, `react-final-form` to `7.0.0`. `final-form` 5.0.1 breaks form submit.
 * blocksmith :: scope text-selection drag guard to editable text so non-text blocks (image, gallery, divider, etc.) stay grab-and-droppable from anywhere on the block.

--- a/src/plugins/notify/components/content-ref-field/index.js
+++ b/src/plugins/notify/components/content-ref-field/index.js
@@ -56,30 +56,28 @@ export default function ContentRefField(props) {
 
   return (
     <div className={contentRef ? 'd-none' : ''}>
-      {options.length > 1 && (
-        <div className={rootClassName} id={`form-group-${selectName}`}>
-          <Label htmlFor={selectName}>
-            Content Type <Badge className="ms-1" color="light" pill>required</Badge>
-          </Label>
-          <ReactSelect
-            id={selectName}
-            name={selectName}
-            className="select"
-            classNamePrefix="select"
-            isDisabled={!editMode || readOnly}
-            options={options}
-            value={currentOption}
-            onChange={(selected) => {
-              if (!selected || selected.value !== type) {
-                contentRefField.input.onChange(undefined);
-                contentRefField.input.onBlur();
-              }
+      <div className={rootClassName} id={`form-group-${selectName}`}>
+        <Label htmlFor={selectName}>
+          Content Type <Badge className="ms-1" color="light" pill>required</Badge>
+        </Label>
+        <ReactSelect
+          id={selectName}
+          name={selectName}
+          className="select"
+          classNamePrefix="select"
+          isDisabled={!editMode || readOnly}
+          options={options}
+          value={currentOption}
+          onChange={(selected) => {
+            if (!selected || selected.value !== type) {
+              contentRefField.input.onChange(undefined);
+              contentRefField.input.onBlur();
+            }
 
-              setType(selected.value);
-            }}
-          />
-        </div>
-      )}
+            setType(selected.value);
+          }}
+        />
+      </div>
       <Suspense fallback={<Loading />}>
         <ErrorBoundary>
           <ContentPickerField

--- a/src/plugins/notify/components/content-ref-field/index.js
+++ b/src/plugins/notify/components/content-ref-field/index.js
@@ -56,28 +56,30 @@ export default function ContentRefField(props) {
 
   return (
     <div className={contentRef ? 'd-none' : ''}>
-      <div className={rootClassName} id={`form-group-${selectName}`}>
-        <Label htmlFor={selectName}>
-          Content Type <Badge className="ms-1" color="light" pill>required</Badge>
-        </Label>
-        <ReactSelect
-          id={selectName}
-          name={selectName}
-          className="select"
-          classNamePrefix="select"
-          isDisabled={!editMode || readOnly}
-          options={options}
-          value={currentOption}
-          onChange={(selected) => {
-            if (!selected || selected.value !== type) {
-              contentRefField.input.onChange(undefined);
-              contentRefField.input.onBlur();
-            }
+      {options.length > 1 && (
+        <div className={rootClassName} id={`form-group-${selectName}`}>
+          <Label htmlFor={selectName}>
+            Content Type <Badge className="ms-1" color="light" pill>required</Badge>
+          </Label>
+          <ReactSelect
+            id={selectName}
+            name={selectName}
+            className="select"
+            classNamePrefix="select"
+            isDisabled={!editMode || readOnly}
+            options={options}
+            value={currentOption}
+            onChange={(selected) => {
+              if (!selected || selected.value !== type) {
+                contentRefField.input.onChange(undefined);
+                contentRefField.input.onBlur();
+              }
 
-            setType(selected.value);
-          }}
-        />
-      </div>
+              setType(selected.value);
+            }}
+          />
+        </div>
+      )}
       <Suspense fallback={<Loading />}>
         <ErrorBoundary>
           <ContentPickerField

--- a/src/plugins/notify/components/create-notification-modal/AppleNewsNotificationModal.js
+++ b/src/plugins/notify/components/create-notification-modal/AppleNewsNotificationModal.js
@@ -4,4 +4,7 @@ function AppleNewsNotificationModal() {
   return null;
 }
 
-export default withNotificationModal(AppleNewsNotificationModal);
+export default withNotificationModal(AppleNewsNotificationModal, {
+  hideSendOptions: true,
+  articleOnly: true,
+});

--- a/src/plugins/notify/components/create-notification-modal/withNotificationModal.js
+++ b/src/plugins/notify/components/create-notification-modal/withNotificationModal.js
@@ -44,16 +44,14 @@ export default function withNotificationModal(ModalFields, modalOptions = {}) {
         const content = getContent(values.content_ref);
         if (content) {
           values.title = content.get('title');
-        } else {
+        }
+
+        if (hideSendOptions || !content) {
           values.send_on_publish = false;
         }
 
-        if (values.send_on_publish || hideSendOptions) {
+        if (hideSendOptions || values.send_on_publish) {
           values.send_at = null;
-        }
-
-        if (hideSendOptions) {
-          values.send_on_publish = false;
         }
 
         await dispatch(createNode(values, form, pbj));

--- a/src/plugins/notify/components/create-notification-modal/withNotificationModal.js
+++ b/src/plugins/notify/components/create-notification-modal/withNotificationModal.js
@@ -18,7 +18,11 @@ import SendOptionsField from '@triniti/cms/plugins/notify/components/send-option
 
 const getContent = ref => getNode(getInstance().getRedux().getState(), ref);
 
-export default function withNotificationModal(ModalFields) {
+const articleContentRefOptions = [{ label: 'Article', value: 'article' }];
+
+export default function withNotificationModal(ModalFields, modalOptions = {}) {
+  const { hideSendOptions = false, articleOnly = false } = modalOptions;
+
   return withForm(function NotificationModal(props) {
     const dispatch = useDispatch();
     const navigate = useNavigate();
@@ -44,8 +48,12 @@ export default function withNotificationModal(ModalFields) {
           values.send_on_publish = false;
         }
 
-        if (values.send_on_publish) {
+        if (values.send_on_publish || hideSendOptions) {
           values.send_at = null;
+        }
+
+        if (hideSendOptions) {
+          values.send_on_publish = false;
         }
 
         await dispatch(createNode(values, form, pbj));
@@ -65,9 +73,12 @@ export default function withNotificationModal(ModalFields) {
         <Form onSubmit={handleSubmit} autoComplete="off">
           <ModalBody>
             {hasSubmitErrors && <FormErrors errors={submitErrors} />}
-            <ContentRefField contentRef={contentRef} />
-            <SendOptionsField contentStatus={contentStatus} />
-            {!values.content_ref && (
+            <ContentRefField
+              contentRef={contentRef}
+              options={articleOnly ? articleContentRefOptions : undefined}
+            />
+            {!hideSendOptions && <SendOptionsField contentStatus={contentStatus} />}
+            {!articleOnly && !values.content_ref && (
               <>
                 <TextField name="title" label="Title" required />
                 <TextareaField name="body" label="Body" rows={5} required />


### PR DESCRIPTION
The Create Notification modal only lets the user pick the article.
Once the notification is created, the user can customize the notification text and choose the "Send At" time from the notification's detail/edit view.
The "Send At" field is removed from the modal entirely.