### PR TITLE
useNode fix

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,7 +2,7 @@
 
 
 ## vN.N.N
-* ncr :: `useNode` refreshNode uses a functional state update so a stale closure can't skip the refetch, which froze the batch uploader's "Saving..." spinner after Apply to All.
+* ncr :: Fix `useNode` refreshNode sometimes skipping the refetch, which froze the batch uploader's "Saving..." spinner after Apply to All.
 * dam :: Batch upload "Apply to All" no longer erases unsaved display title and alt text on the active asset form.
 * Polish apple news modal
 * iam :: Auto-reload on expired auth outside edit screens. Keep "Authentication Required" modal only in edit mode so in-progress work isn't lost.

--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,7 @@
 
 
 ## vN.N.N
+* ncr :: `useNode` refreshNode uses a functional state update so a stale closure can't skip the refetch, which froze the batch uploader's "Saving..." spinner after Apply to All.
 * dam :: Batch upload "Apply to All" no longer erases unsaved display title and alt text on the active asset form.
 * Polish apple news modal
 * iam :: Auto-reload on expired auth outside edit screens. Keep "Authentication Required" modal only in edit mode so in-progress work isn't lost.

--- a/src/plugins/ncr/components/useNode.js
+++ b/src/plugins/ncr/components/useNode.js
@@ -97,7 +97,10 @@ export default (nodeRef, consistent = false) => {
       return;
     }
 
-    setRefreshCount(refreshCount + 1);
+    // functional update because callers can hold this closure from an old render
+    // (e.g. the uploader modal's save button) computing from the captured count
+    // would set the same value, bail out, and skip the refetch.
+    setRefreshCount(count => count + 1);
   };
 
   return {


### PR DESCRIPTION
* ncr :: `useNode` refreshNode uses a functional state update so a stale closure can't skip the refetch, which froze the batch uploader's "Saving..." spinner after Apply to All.