### PR TITLE
Batch Upload form's "Apply To All" - Fix Adjustment

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,7 @@
 
 
 ## vN.N.N
+* dam :: Adjust batch upload form's "Apply To All" issue fix to address a new regression that after saving ( ex. adding people on arrticle ), the save button remains enabled.
 * blocksmith :: Parse and save TikTok username in tiktok-embed-block modal.
 * notify :: Remove Apple News option from create notification modal.
 * ncr :: Fix `useNode` refreshNode sometimes skipping the refetch, which froze the batch uploader's "Saving..." spinner after Apply to All.

--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,7 +2,7 @@
 
 
 ## vN.N.N
-* dam :: Adjust batch upload form's "Apply To All" issue fix to address a new regression that after saving ( ex. adding people on arrticle ), the save button remains enabled.
+* dam :: Adjust batch upload form's "Apply To All" fix to address a new regression that after saving an article, the save button remains enabled.
 * blocksmith :: Parse and save TikTok username in tiktok-embed-block modal.
 * notify :: Remove Apple News option from create notification modal.
 * ncr :: Fix `useNode` refreshNode sometimes skipping the refetch, which froze the batch uploader's "Saving..." spinner after Apply to All.

--- a/src/components/with-form/index.js
+++ b/src/components/with-form/index.js
@@ -79,6 +79,7 @@ export default function withForm(Component, config = {}) {
                 delegate.reinitialize = false;
                 setTimeout(() => {
                   form.batch(() => {
+                    form.setConfig('keepDirtyOnReinitialize', false);
                     form.reset();
                     form.restart();
                     form.setConfig('keepDirtyOnReinitialize', config.keepDirtyOnReinitialize);

--- a/src/plugins/dam/components/uploader-modal/useDelegate.js
+++ b/src/plugins/dam/components/uploader-modal/useDelegate.js
@@ -76,14 +76,18 @@ export default (props) => {
     try {
       await progressIndicator.show(`Applying [${field}] to ${refs.length} assets...`);
       await dispatch(patchAssets(refs, { [field]: value }));
-      form.setConfig('keepDirtyOnReinitialize', true);
+      const dirtyEntries = Object.keys(formState.dirtyFields)
+        .filter(fieldName =>  fieldName !== field)
+        .map(fieldName => [fieldName, formState.values[fieldName]]);
       delegate.shouldReinitialize = true;
       delegate.onAfterReinitialize = () => {
-        // reinitialize runs restart(), which clears touched on every field. Re-mark the
-        // fields that still hold unsaved edits so they keep their green (edited) indicator;
-        // the applied field now matches the server (pristine) and is left unmarked.
-        const { dirtyFields } = form.getState();
-        Object.keys(dirtyFields).forEach((name) => form.blur(name));
+        // manually restore stored form dirty entries
+        dirtyEntries
+          .forEach(([fieldName, value]) => {
+            form.change(fieldName, value);
+            // Re-mark the fields that still hold unsaved values so they keep their green (edited) indicator.
+            form.blur(fieldName);
+          });
         progressIndicator.close();
         toast({ title: `Applied [${field}] to ${refs.length} assets.` });
       };

--- a/src/plugins/dam/components/uploader-modal/useDelegate.js
+++ b/src/plugins/dam/components/uploader-modal/useDelegate.js
@@ -81,13 +81,16 @@ export default (props) => {
         .map(fieldName => [fieldName, formState.values[fieldName]]);
       delegate.shouldReinitialize = true;
       delegate.onAfterReinitialize = () => {
-        // manually restore stored form dirty entries
-        dirtyEntries
-          .forEach(([fieldName, value]) => {
-            form.change(fieldName, value);
-            // Re-mark the fields that still hold unsaved values so they keep their green (edited) indicator.
-            form.blur(fieldName);
-          });
+        // reinitialize runs restart(), which clears touched on every field. Restore and re-mark the
+        // fields that still hold unsaved edits so they keep their green (edited) indicator;
+        // the applied field now matches the server (pristine) and is left unmarked.
+        form.batch(() => {
+          dirtyEntries
+            .forEach(([fieldName, value]) => {
+              form.change(fieldName, value);
+              form.blur(fieldName);
+            });
+        });
         progressIndicator.close();
         toast({ title: `Applied [${field}] to ${refs.length} assets.` });
       };


### PR DESCRIPTION

1. revert change on `withForm` HoC.

2.  i believe that batch upload "Apply To All" issue is a unique case that the fix should just be isolated inside its component. so manually restore dirty fields instead of reconfiguring the form's `keepDirtyOnReinitialize` config on runtime.